### PR TITLE
Fix 'multiple definition' linker errors

### DIFF
--- a/makefile
+++ b/makefile
@@ -3,7 +3,7 @@ LDFLAGS  = `sdl2-config --libs` -lSDL2 -lSDL2_ttf -lm
 PROG = spritely
 CXX = gcc
 
-OBJS = main.o spritely.o input.o init.o util.o context.o file.o message_queue.o
+OBJS = main.o spritely.o input.o init.o util.o context.o file.o message_queue.o globals.o
 
 # top-level rule to create the program.
 all: $(PROG)

--- a/src/globals.c
+++ b/src/globals.c
@@ -1,0 +1,28 @@
+#include "globals.h"
+
+struct mouse mouse;
+
+SDL_Window *window;
+SDL_Renderer *renderer;
+
+char pen_color;
+int current_sprite_index;
+int copy_index;
+int lctrl;
+color_t clipboard_pixel_buffer[SPRITE_CANVAS_SIZE];
+Context_t sprite_canvas_ctx;
+Context_t color_picker_ctx;
+Context_t sprite_selector_ctx;
+Context_t sprite_sheet_current_cell_ctx;
+Context_t sprite_selector_cells[SPRITESHEET_SIZE];
+Context_t color_selector_cells[COLORPICKER_CANVAS_SIZE];
+
+SDL_Rect sprite_selection_indicator;
+SDL_Rect color_picker_indicator;
+
+uint sprite_sheet[SPRITESHEET_SIZE][SPRITE_CANVAS_SIZE];
+
+Message_Queue_t command_message_queue;
+
+unsigned int current_time;
+unsigned int last_time;

--- a/src/globals.h
+++ b/src/globals.h
@@ -5,37 +5,39 @@ struct mouse
 {
     int x;
     int y;
-} mouse;
+};
+
+extern struct mouse mouse;
 
 #include "defs.h"
 #include "colors.h"
 #include "message_queue.h"
 #include "context.h"
 
-SDL_Window *window;
-SDL_Renderer *renderer;
+extern SDL_Window *window;
+extern SDL_Renderer *renderer;
 
 //TODO: move these into spritely
-char pen_color;
-int current_sprite_index;
-int copy_index;
-int lctrl;
-color_t clipboard_pixel_buffer[SPRITE_CANVAS_SIZE];
-Context_t sprite_canvas_ctx;
-Context_t color_picker_ctx;
-Context_t sprite_selector_ctx;
-Context_t sprite_sheet_current_cell_ctx;
-Context_t sprite_selector_cells[SPRITESHEET_SIZE];
-Context_t color_selector_cells[COLORPICKER_CANVAS_SIZE];
+extern char pen_color;
+extern int current_sprite_index;
+extern int copy_index;
+extern int lctrl;
+extern color_t clipboard_pixel_buffer[SPRITE_CANVAS_SIZE];
+extern Context_t sprite_canvas_ctx;
+extern Context_t color_picker_ctx;
+extern Context_t sprite_selector_ctx;
+extern Context_t sprite_sheet_current_cell_ctx;
+extern Context_t sprite_selector_cells[SPRITESHEET_SIZE];
+extern Context_t color_selector_cells[COLORPICKER_CANVAS_SIZE];
 
-SDL_Rect sprite_selection_indicator;
-SDL_Rect color_picker_indicator;
+extern SDL_Rect sprite_selection_indicator;
+extern SDL_Rect color_picker_indicator;
 
-uint sprite_sheet[SPRITESHEET_SIZE][SPRITE_CANVAS_SIZE];
+extern uint sprite_sheet[SPRITESHEET_SIZE][SPRITE_CANVAS_SIZE];
 
-Message_Queue_t command_message_queue;
+extern Message_Queue_t command_message_queue;
 
-unsigned int current_time;
-unsigned int last_time;
+extern unsigned int current_time;
+extern unsigned int last_time;
 
 #endif


### PR DESCRIPTION
When linking, both `main.o` and `spritely.o` had definitions for `mouse`, `window`, `renderer`, etc. which caused building to fail.
e.g.
```
/usr/bin/ld: spritely.o:/home/user/Desktop/spritely/src/globals.h:17: multiple definition of 'window'; main.o:/home/user/Desktop/spritely/src/globals.h:17: first defined here
```

Fix by using `extern` keyword in `globals.h` and have the single definition come from `globals.c`