### PR TITLE
indicator moved to inside context adt

### DIFF
--- a/src/context.h
+++ b/src/context.h
@@ -23,20 +23,28 @@ extern void Context_handle_rect_click(Context_t ctx, void  (*fn)(const unsigned 
 /* swap the pixels from one Context to another */
 extern void Context_swap_pixels(Context_t dest, Context_t source);
 
-/* moves a Context to the position of another Context's first pixel.  This is good for indicators
-*   (i.e. move one pixel on tope of another)
-*   (e.g. the sprite selector has an indicator that follows where we click the mouse to show which sprite we are currently editing)
-*/
-extern void Context_focus(Context_t dest, Context_t source);
 extern void Context_from_pixel_buffer(Context_t ctx, color_t *pixel_buffer);
 extern void Context_to_pixel_buffer(Context_t ctx, color_t *pixel_buffer);
 extern color_t Context_get_pixel (Context_t ctx, const unsigned char pixel_index);
 extern void Context_set_pixel(Context_t ctx, const unsigned char pixel_index, color_t color);
-extern void Context_indicator_focus(SDL_Rect *indicator, Context_t ctx, const unsigned char rect_index);
+extern void Context_indicator_focus(Context_t ctx, const unsigned char rect_index);
+
+/**
+ * Context_make_indicator
+ * make an indicator for the context.  When a cell in the context is clicked,
+ * it will be highlighted.
+ */
+extern void Context_make_indicator(Context_t ctx);
 
 extern void Context_free_future_commits(Context_t ctx);
 extern void Context_new_commit(Context_t ctx, color_t pre_color, color_t post_color, uint position);
 extern void Context_move_commits(Context_t ctx, int offset);
+
+/**
+ * Context_make_transparent - the context will not render if this is executed, 
+ * but the indicator will render
+ */
+extern void Context_make_transparent(Context_t ctx);
 
 /* Return 1 if the ctx is entirely the given color else return 0 */
 extern int Context_is_solid_color(Context_t ctx, color_t color);

--- a/src/defs.h
+++ b/src/defs.h
@@ -1,15 +1,12 @@
 #include <SDL2/SDL.h>
 #include <stdio.h>
+#include <stdbool.h>
 
 #ifndef _GLOBAL_CONSTANTS
 #define _GLOBAL_CONSTANTS
 
-#if 0
-#define __DEBUG_SPRITE_SELECTOR__
-#endif
-
 #define SCREEN_WIDTH 672
-#define SCREEN_HEIGHT 568
+#define SCREEN_HEIGHT 565
 
 #define SPRITE_CANVAS_SIZE 64
 #define SPRITE_CANVAS_PIXEL_SIZE 50

--- a/src/globals.c
+++ b/src/globals.c
@@ -15,11 +15,9 @@ Context_t sprite_canvas_ctx;
 Context_t color_picker_ctx;
 Context_t sprite_selector_ctx;
 Context_t sprite_sheet_current_cell_ctx;
+Context_t toolbar_ctx;
 Context_t sprite_selector_cells[SPRITESHEET_SIZE];
 Context_t color_selector_cells[COLORPICKER_CANVAS_SIZE];
-
-SDL_Rect sprite_selection_indicator;
-SDL_Rect color_picker_indicator;
 
 uint sprite_sheet[SPRITESHEET_SIZE][SPRITE_CANVAS_SIZE];
 

--- a/src/globals.h
+++ b/src/globals.h
@@ -28,11 +28,9 @@ extern Context_t sprite_canvas_ctx;
 extern Context_t color_picker_ctx;
 extern Context_t sprite_selector_ctx;
 extern Context_t sprite_sheet_current_cell_ctx;
+extern Context_t toolbar_ctx;
 extern Context_t sprite_selector_cells[SPRITESHEET_SIZE];
 extern Context_t color_selector_cells[COLORPICKER_CANVAS_SIZE];
-
-extern SDL_Rect sprite_selection_indicator;
-extern SDL_Rect color_picker_indicator;
 
 extern uint sprite_sheet[SPRITESHEET_SIZE][SPRITE_CANVAS_SIZE];
 

--- a/src/init.c
+++ b/src/init.c
@@ -15,11 +15,14 @@ static int create_window()
 {
     window = NULL;
 
+
+    SDL_SetHint(SDL_HINT_EMSCRIPTEN_KEYBOARD_ELEMENT, "#canvas"); /* disable key inputs in wasm */
+
     window = SDL_CreateWindow(
         "spritely",
         SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
         SCREEN_WIDTH, SCREEN_HEIGHT,
-        SDL_WINDOW_SHOWN);
+        SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE);
     if (window == NULL)
     {
         fprintf(stderr, "could not create window: %s\n", SDL_GetError());

--- a/src/input.c
+++ b/src/input.c
@@ -87,14 +87,21 @@ static void tool_fill(const unsigned char rect_index)
 static void tool_sprite_selection(const unsigned char rect_index)
 {
     current_sprite_index = rect_index;
-    Context_indicator_focus(&sprite_selection_indicator, sprite_selector_ctx, current_sprite_index);
+    Context_indicator_focus(sprite_selector_ctx, current_sprite_index);
     Context_swap_pixels(sprite_canvas_ctx, sprite_selector_cells[rect_index]);
+}
+
+static void tool_toolbar_selection(const unsigned char rect_index)
+{
+/**
+ * this is where we can handle which tool is selected based on 
+ * which thing on the toolbar is active
+ */
 }
 
 static void tool_color_pick(const unsigned char rect_index)
 {
     pen_color = rect_index;
-    Context_indicator_focus(&color_picker_indicator, color_picker_ctx, pen_color);
 }
 
 static void left_clicks()
@@ -107,6 +114,7 @@ static void left_clicks()
 
     Context_handle_rect_click(color_picker_ctx, tool_color_pick);
     Context_handle_rect_click(sprite_selector_ctx, tool_sprite_selection);
+    Context_handle_rect_click(toolbar_ctx, tool_toolbar_selection);
 }
 
 static void right_clicks()


### PR DESCRIPTION
- indicators are now internal to the context adt
- adding a temporary context for the toolbar
- making SDL window resizeable
- disabling inputs on wasm build