### PR TITLE
Fix memory leak in Context_render_icon()

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -80,12 +80,14 @@ void Context_free(Context_t ctx)
 
 void Context_render_icon(Context_t ctx, char *filename, uint index)
 {
+    /* TODO: Avoid loading this stuff on *every* frame */
     SDL_Surface* surface = IMG_Load(filename); 
     SDL_Texture* texture = SDL_CreateTextureFromSurface(renderer, surface); 
     SDL_FreeSurface(surface);
 
 
     SDL_RenderCopy(renderer, texture, NULL, &ctx->rects[index]);
+    SDL_DestroyTexture(texture);
 }
 
 void Context_make_transparent(Context_t ctx)


### PR DESCRIPTION
Without this fix, the program runs out of memory, printing a whole
bunch of these messages:

	libpng error: Decompression error

At the same time these messages appear, the toolbar disappears
(which was a big clue to find the source of the problem).

And it eventually core dumps in some arbitrary place (usually deep in
some library that's unrelated tot he problem) when malloc returns a
virtual address that cannot be backed up by RAM (or returns 0 if
overcommit is turned off, but overcommit is almost never turned off.)

This fix works, but it's not ideal, as Context_render_icon() is reloading
the icons on *every frame*, and they should really only be done once
(could be done by polling with stat() or use inotify if you want to be
fancy.)

Signed-off-by: Stephen M. Cameron <stephenmcameron@gmail.com>