### PR TITLE
Fix potential infinite loop in util.c:find_last_occurrence()

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -43,7 +43,7 @@ void *checked_malloc(size_t size) {
 }
 
 size_t find_last_occurrence(const char *const buf, const size_t buf_len, const char ch) {
-    for (size_t i = buf_len - 1; i >= 0; i -= 1) {
+    for (size_t i = buf_len - 1; i != (size_t) -1; i--) {
         if (buf[i] == ch) {
             return i;
         }


### PR DESCRIPTION
Loop counter is unsigned, so will always be >= 0 so if the
occurrence is not present, it will very likely crash when the
loop counter wraps around when it passes 0 and becomes (2^64)-1.

Signed-off-by: Stephen M. Cameron <stephenmcameron@gmail.com>