### PR TITLE
adding a way to call scripts

### DIFF
--- a/makefile
+++ b/makefile
@@ -7,7 +7,7 @@ CC = gcc
 
 SRCS = $(addprefix src/, main.c spritely.c init.c util.c context.c file.c \
 message_queue.c globals.c colors.c sfd.c draw_tools.c sprite_sheet.c app_state.c \
-sprite_editor.c shell.c)
+sprite_editor.c shell.c python_api.c)
 OBJS = $(SRCS:.c=.o)
 
 # top-level rule to create the program.

--- a/spits/hello_world.spit
+++ b/spits/hello_world.spit
@@ -1,0 +1,4 @@
+
+def hello_world(): print("Hello, World!")
+
+hello_world()

--- a/src/globals.h
+++ b/src/globals.h
@@ -19,6 +19,7 @@ extern struct mouse mouse;
 #include "app_state.h"
 #include "sprite_editor.h"
 #include "shell.h"
+#include "python_api.h"
 
 extern SDL_Window *window;
 extern SDL_Renderer *renderer;

--- a/src/main.c
+++ b/src/main.c
@@ -1,7 +1,15 @@
 #include "main.h"
 
+
 int main(int argc, char *args[])
 {
+#ifndef __EMSCRIPTEN__
+  if (argc > 1) {
+    if(strcmp(get_filename_ext(args[1]), "spit") == 0)
+      run_spit_file(args[1]);
+  }
+#endif
+
   if (!init_everything())
     return -1;
 

--- a/src/python_api.c
+++ b/src/python_api.c
@@ -1,0 +1,16 @@
+#include "globals.h"
+#ifndef __EMSCRIPTEN__
+
+void run_spit_file(char *filename)
+{
+	FILE* fp;
+
+	Py_Initialize();
+
+	fp = _Py_fopen(filename, "rb");
+	PyRun_SimpleFile(fp, filename);
+
+	Py_Finalize();
+}
+
+#endif

--- a/src/python_api.h
+++ b/src/python_api.h
@@ -1,0 +1,14 @@
+#ifndef _PYTHON_API
+#define _PYTHON_API
+
+#ifndef __EMSCRIPTEN__
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+
+
+extern void run_spit_file(char *filename);
+#endif
+
+#endif

--- a/src/shell.c
+++ b/src/shell.c
@@ -1,10 +1,4 @@
 
-#ifndef __EMSCRIPTEN__
-
-#define PY_SSIZE_T_CLEAN
-#include <Python.h>
-
-#endif
 #include "globals.h"
 
 #define IO_BUFFER_SIZE 50

--- a/src/util.c
+++ b/src/util.c
@@ -65,3 +65,10 @@ int canvas_index_in_range(const unsigned int index)
 
     return 0;
 }
+
+
+const char *get_filename_ext(const char *filename) {
+    const char *dot = strrchr(filename, '.');
+    if(!dot || dot == filename) return "";
+    return dot + 1;
+}

--- a/src/util.h
+++ b/src/util.h
@@ -23,3 +23,5 @@ extern int sprite_sheet_index_in_range(const unsigned int index);
 * Return 1 if the index is within the spritesheet range
 */
 extern int canvas_index_in_range(const unsigned int index);
+
+extern const char *get_filename_ext(const char *filename);


### PR DESCRIPTION
can now pass in python scripts 
A script can be passed in as an argument
```sh
./spritely spits/hello_world.spit
```
or by calling the ` run_spit_file ` function

I gave them their own file extension because eventually we will extend the python language and you won't be able to run these scripts on a standard python interpretter.