### PR TITLE
Added github action to test standard build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # spritely
+<img alt="GitHub Workflow Status" src="https://img.shields.io/github/workflow/status/dfirebaugh/spritely/Build%20and%20deploy">
+
 Spritely is a sprite editor for making tiny sprites.
 Spritely makes a 64 sprite sprite sheet in the format of png.  Each sprite is 8x8 pixels with 16 colors.
 


### PR DESCRIPTION
Fixes #73 

This PR is about adding a github action to test standard build

How has this been fixed ?

* Added a icon for passing or failing the build under `README.md`
* Used icon from [Shields.io](https://shields.io/category/build)

Please find the updated file [here](https://github.com/yash2189/spritely/blob/fix-%2373/README.md)