### PR TITLE
Allow drag and pen on mouse hold

### DIFF
--- a/src/draw_tools.c
+++ b/src/draw_tools.c
@@ -188,7 +188,7 @@ static void tool_drag(const unsigned int rect_index)
 
     if(previous_rect_index + SPRITE_CANVAS_ROW_SIZE == rect_index)
         shift_down();
-    
+
     if(previous_rect_index - 1 == rect_index)
         shift_left();
 
@@ -226,6 +226,15 @@ void left_clicks()
     Context_handle_rect_click(color_picker_ctx, tool_color_pick);
     Context_handle_rect_click(sprite_selector_ctx, tool_sprite_selection);
     Context_handle_rect_click(toolbar_ctx, tool_toolbar_selection);
+}
+
+void left_drags()
+{
+    if (active_tool == DRAG) {
+        Context_handle_rect_click(sprite_canvas_ctx, tool_drag);
+    } else if (active_tool == PEN) {
+        Context_handle_rect_click(sprite_canvas_ctx, tool_pen);
+    }
 }
 
 void right_clicks()

--- a/src/draw_tools.h
+++ b/src/draw_tools.h
@@ -15,6 +15,7 @@ extern void copy_sprite();
 extern void paste_sprite();
 extern void right_clicks();
 extern void left_clicks();
+extern void left_drags();
 extern void show_help();
 extern void tool_sprite_selection(const unsigned int rect_index);
 

--- a/src/globals.h
+++ b/src/globals.h
@@ -5,6 +5,8 @@ struct mouse
 {
     int x;
     int y;
+    int canvas_x;
+    int canvas_y;
 };
 
 extern struct mouse mouse;

--- a/src/sprite_editor.c
+++ b/src/sprite_editor.c
@@ -174,11 +174,19 @@ void sprite_editor_inputs(SDL_Event event)
     case SDL_MOUSEMOTION:
         mouse.x = event.motion.x;
         mouse.y = event.motion.y;
+        int canvas_x = (event.motion.x / SPRITE_CANVAS_PIXEL_SIZE);
+        int canvas_y = (event.motion.y / SPRITE_CANVAS_PIXEL_SIZE);
+        if (canvas_x != mouse.canvas_x || canvas_y != mouse.canvas_y) {
+            mouse.canvas_x = canvas_x;
+            mouse.canvas_y = canvas_y;
+            if (mousedown && event.motion.state & SDL_BUTTON_LMASK)
+                left_drags();
+        }
     case SDL_MOUSEBUTTONDOWN:
         mousedown=true;
         break;
     case SDL_MOUSEBUTTONUP:
-        if(mousedown) 
+        if(mousedown)
         {
             switch (event.button.button)
             {


### PR DESCRIPTION
This PR intends to close #84 by enabling both PEN and DRAG tools to be triggered while dragging the mouse on the canvas while holding the left button.

The `left_drags` function was created in `draw_tools` in the same format as `left_clicks`, except it only affects PEN/DRAG, and dispatches the same click events to the sprite canvas context.

In order to minimize calls to this function, the canvas position of the mouse is now tracked in the `mouse` struct, and new events are only fired when the mouse moves to a different pixel.

Any feedback is appreciated! :)