### PR TITLE
[Bug] The first sprite is not drew on the canvas at spritesheet onload event

### DIFF
--- a/src/draw_tools.c
+++ b/src/draw_tools.c
@@ -329,8 +329,8 @@ void draw_tool_handle_redo()
 
 void draw_tool_handle_open_file()
 {
-    tool_sprite_selection(0);
     open_file();
+    tool_sprite_selection(0);
 }
 
 static void tool_toolbar_selection(const unsigned int rect_index)


### PR DESCRIPTION
Issue #89 
Re-order the code so it draws the 1st sprite after the spritesheet is loaded