### PR TITLE
Free filename_buf in save_sprites error handling and update color_values comment

### DIFF
--- a/src/colors.h
+++ b/src/colors.h
@@ -28,8 +28,9 @@ typedef enum color {
 } color_t;
 
 // A one-dimensional array holding RGBA components for all color_t values
-// e.g. color_components[color_t value] == Red component of that color
-//  immediately followed by green, blue, and alpha component values
+// e.g. color_values[color_t value * NUM_COLOR_COMPONENTS] is the red
+//  component of that color immediately followed by green, blue, and
+//  alpha component values
 extern uint8_t color_values[COLOR_VALUES_SIZE];
 
 #endif

--- a/src/file.c
+++ b/src/file.c
@@ -124,6 +124,7 @@ static void save_sprites(
 
             if (write_code == 0) {
                 Message_Queue_enqueue(command_message_queue, "Error outputting sprites", 0);
+                free(filename_buf);// Clean up
                 return;// Do not attempt to output any more images
             }
 


### PR DESCRIPTION
The function `save_sprites` in `src/file.c` allocates memory with malloc:

https://github.com/dfirebaugh/spritely/blob/1411138521dcc3070cc5840914eda42fe87e2c6c/src/file.c#L88

Normally this memory is freed at the end of the function:

https://github.com/dfirebaugh/spritely/blob/1411138521dcc3070cc5840914eda42fe87e2c6c/src/file.c#L134

It is possible for the function to return early if the `stbi_write_png` call is not successful:

https://github.com/dfirebaugh/spritely/blob/1411138521dcc3070cc5840914eda42fe87e2c6c/src/file.c#L116-L128

`filename_buf` must be freed before this early return, otherwise the memory is leaked.
This PR adds the necessary `free` call.

This PR also updates the comment for `color_values` in `src/colors.h`:
- Use the correct name for the array
- The color_t value must be multiplied by `NUM_COLOR_COMPONENTS` for the index to be correct