### PR TITLE
Don't reload the toolbar icons every time the toolbar is rendered

### DIFF
--- a/makefile
+++ b/makefile
@@ -17,10 +17,10 @@ $(PROG): $(OBJS)
 
 # cleaning everything that can be automatically recreated with "make"
 clean:
-	rm $(PROG) $(OBJS)
+	rm -f $(PROG) $(OBJS)
 
 clean-web:
-	rm web/index.js web/index.wasm
+	rm -f web/index.js web/index.wasm
 
 web:
 	emcc $(SRCS) -s WASM=1 -s USE_SDL=2 -s USE_SDL_TTF=2 \

--- a/src/sprite_editor.c
+++ b/src/sprite_editor.c
@@ -7,14 +7,16 @@ static void toolbar_render(Context_t ctx)
 {
     uint8_t i;
 
-    Sprite_sheet_t icon_sprite_sheet = Sprite_sheet_make("assets/icons/icons.png");
+    static Sprite_sheet_t icon_sprite_sheet = NULL;
+
+    if (!icon_sprite_sheet)
+        icon_sprite_sheet = Sprite_sheet_make("assets/icons/icons.png");
 
 
     for (i = 0; i < TOOLBAR_ROW_SIZE; i++)
     {
         Context_render_sprite_in_context_scale(toolbar_ctx, icon_sprite_sheet, i, i, 6);
     }
-    Sprite_sheet_free(icon_sprite_sheet);
 }
 
 /**


### PR DESCRIPTION
Also use "-f" option of rm in the "clean" makefile target so if you run "make clean" 2x in a row, the 2nd attempt doesn't fail.